### PR TITLE
Improve code comments and README clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The ProfitScout Data Pipeline is a fully automated, serverless system built on G
 * **Automated SEC Filing Extraction**: Intelligently extracts the Business, Risk Factors, and MD&A sections from the latest annual and quarterly company filings.
 * **Comprehensive Financial Data Collection**: Fetches and stores the last 8 quarters of financial statements and fundamentals (key metrics, ratios).
 * **Daily Market Data Updates**: Collects a 90-day snapshot of historical price data and a suite of technical indicators (SMA, EMA, RSI, etc.).
+* **Bulk Historical Price Loading**: Populates BigQuery with full price history for all tracked tickers.
 * **AI-Powered Summarization**: Automates the fetching of earnings call transcripts and uses Google's Gemini API to generate structured, insightful summaries focused on financial signals.
 * **Declarative & Parallel Orchestration**: Utilizes Cloud Workflows to manage the entire pipeline, running independent data collection tasks in parallel for maximum efficiency.
 * **Fully Automated & Scheduled**: Triggered automatically by Cloud Scheduler for timely and consistent data freshness without manual intervention.
@@ -77,6 +78,7 @@ This project was built with professional-grade engineering practices in mind. Th
 | **`sec_filing_extractor`** | `extract_sec_filings` | HTTP | Extracts Business, MD&A, and Risk Factors from the latest SEC filings. |
 | **`fundamentals`** | `refresh_fundamentals`| HTTP | Fetches and stores 8 quarters of financial fundamentals and ratios. |
 | **`price_updater`** | `update_prices`| HTTP | Fetches a 90-day snapshot of historical price data. |
+| **`statement_loader`** | `load_statements` | HTTP | Retrieves and stores 8 quarters of income, balance sheet, and cash flow statements. |
 | **`populate_price_data`** | `populate_price_data` | HTTP | Loads historical price data for tracked tickers into BigQuery. |
 | **`technicals_collector`** | `refresh_technicals` | HTTP | Collects a suite of daily technical indicators (SMA, EMA, RSI, etc.). |
 | **`transcript_collector`**| `refresh_transcripts`| HTTP | Fetches the latest quarterly earnings call transcript. |

--- a/technicals_collector/core/orchestrator.py
+++ b/technicals_collector/core/orchestrator.py
@@ -16,10 +16,7 @@ from config import (
 )
 from core.gcs import get_tickers, upload_json_to_gcs
 
-# FIX: Remove the global BigQuery client initialization from this file.
-# bq_client = bigquery.Client(project=PROJECT_ID) # <-- THIS LINE IS REMOVED
-
-# FIX: Update function to receive the bq_client as an argument.
+# The BigQuery client is created in main.py and passed to these functions.
 def get_all_price_histories(tickers: list[str], bq_client: bigquery.Client) -> pd.DataFrame:
     """
     Fetches OHLCV data for ALL tickers in a single, efficient BigQuery query.

--- a/transcript_collector/backfill_transcripts.py
+++ b/transcript_collector/backfill_transcripts.py
@@ -3,7 +3,7 @@ import logging
 import datetime
 import pandas as pd
 import requests
-import json # <-- ADDED: Import Python's standard JSON library
+import json
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from threading import Lock
 import time
@@ -12,7 +12,6 @@ from google.cloud import bigquery, storage
 from tenacity import retry, stop_after_attempt, wait_exponential
 
 # --- Configuration ---
-# ---!!!--- Make sure these values are correct ---!!!---
 PROJECT_ID = "profitscout-lx6bb"
 GCS_BUCKET_NAME = "profit-scout-data"
 BIGQUERY_TABLE_ID = "profitscout-lx6bb.profit_scout.stock_metadata"
@@ -122,7 +121,6 @@ def process_record(record, fmp_client: FMPClient, storage_client: storage.Client
             return f"NO_CONTENT: {ticker} for {year} Q{quarter}"
 
         # 3. Upload the fetched data to GCS
-        # <-- FIXED: Use the standard json.dumps() to convert the dict to a string
         blob.upload_from_string(json.dumps(transcript_data, indent=2), content_type="application/json")
         return f"SUCCESS: Fetched and uploaded for {ticker} on {quarter_end_date}"
 

--- a/transcript_summarizer/core/gcs.py
+++ b/transcript_summarizer/core/gcs.py
@@ -1,10 +1,5 @@
 # transcript_summarizer/core/gcs.py
-"""
-Very small helper for reading/writing text blobs in GCS.
-"""
-from google.cloud import storage
-
-# transcript_summarizer/core/gcs.py
+"""Helper functions for reading and writing text blobs in GCS."""
 from google.cloud import storage
 
 def _client() -> storage.Client:

--- a/transcript_summarizer/delete_summaries.py
+++ b/transcript_summarizer/delete_summaries.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from google.cloud import storage
 
 # --- Configuration ---
-# Please confirm these values are correct before running.
 PROJECT_ID = "profitscout-lx6bb"
 GCS_BUCKET_NAME = "profit-scout-data"
 SUMMARIES_PREFIX = "earnings-call-summaries/"
@@ -26,8 +25,7 @@ def delete_summaries_by_date():
         # Parse the target date string into a date object
         target_date = datetime.strptime(DATE_TO_DELETE, "%Y-%m-%d").date()
 
-        # --- FIXED LOGIC ---
-        # Find all blobs and filter by their 'time_created' metadata attribute
+    # Find all blobs and filter by their 'time_created' metadata attribute
         all_blobs = bucket.list_blobs(prefix=SUMMARIES_PREFIX)
         blobs_to_delete = []
         for blob in all_blobs:
@@ -43,7 +41,7 @@ def delete_summaries_by_date():
         for blob in blobs_to_delete:
             print(f"  - {blob.name} (Created: {blob.time_created.date()})")
 
-        # --- SAFETY CONFIRMATION STEP ---
+        # Confirm deletion with the user
         confirm = input("\nAre you sure you want to permanently delete these files? (yes/no): ")
 
         if confirm.lower() == 'yes':

--- a/transcript_summarizer/main.py
+++ b/transcript_summarizer/main.py
@@ -32,8 +32,6 @@ def _process_blob(blob: Blob):
     try:
         # Read and parse the transcript JSON
         logging.info(f"Processing transcript: {blob_name}")
-        # --- FIX ---
-        # Changed gcs.read_text to gcs.read_blob to match the function name in your gcs.py
         raw_json = gcs.read_blob(config.GCS_BUCKET, blob_name)
         content, year, quarter = utils.read_transcript_data(raw_json)
 


### PR DESCRIPTION
## Summary
- clean up outdated comments in various modules
- streamline helper documentation in `gcs.py`
- clarify README core features
- include `statement_loader` in service breakdown table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864616dbe94833183d7a9564f979376