### PR TITLE
Fix README to match current pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,23 +25,30 @@ The entire pipeline is orchestrated by Cloud Workflows, which ensures tasks are 
 ```mermaid
 graph TD
     subgraph "Google Cloud Project"
-        A[Cloud Scheduler] -->|Every Weekday at 5 PM ET| B(Cloud Workflow: profitscout-pipeline);
+        A[Cloud Scheduler] -->|Every Weekday at 5 PM ET| B(Cloud Workflow: profitscout-pipeline)
 
-        B -->|Invokes in Parallel| C1[Function: extract-sec-filings];
-        B -->|Invokes in Parallel| C2[Function: refresh-fundamentals];
-        B -->|Invokes in Parallel| C3[Function: refresh-prices];
-        B -->|Invokes in Parallel| C4[Function: refresh-technicals];
+        B -->|Invokes in Parallel| C1[Function: sec_filing_extractor]
+        B -->|Invokes in Parallel| C2[Function: statement_loader]
+        B -->|Invokes in Parallel| C3[Function: fundamentals]
+        B -->|Invokes in Parallel| C4[Function: populate_price_data]
+        B -->|Invokes in Parallel| C5[Function: price_updater]
+        B -->|Invokes in Parallel| C6[Function: technicals_collector]
+        B -->|Invokes in Parallel| C7[Function: refresh_stock_metadata]
 
-        C1 --> E[(Cloud Storage)];
-        C2 --> E;
-        C3 --> E;
-        C4 --> E;
-
-        F[Pub/Sub: transcripts-topic] --> G[Function: create-transcript-summaries];
-        D[Function: refresh-transcripts] --> F;
-        D --> E;
-        G --> E[fa:fa-database GCS Buckets];
+        C1 --> S[(Cloud Storage)]
+        C2 --> S
+        C3 --> S
+        C5 --> S
+        C6 --> S
+        C4 --> Q[(BigQuery)]
+        C7 --> Q
     end
+```
+
+```mermaid
+graph LR
+    TC[transcript_collector] --> P[Pub/Sub]
+    P --> TS[transcript_summarizer]
 ```
 ## 4. Technology Stack
 
@@ -50,6 +57,8 @@ graph TD
 * **Orchestration**: Cloud Workflows
 * **Scheduling**: Cloud Scheduler
 * **Storage**: Cloud Storage
+* **Data Warehouse**: BigQuery
+* **Messaging**: Pub/Sub
 * **Security**: Secret Manager
 * **Language**: Python
 * **Key Libraries**: `google-cloud-storage`, `requests`, `tenacity`, `google-genai`
@@ -84,8 +93,9 @@ This project was built with professional-grade engineering practices in mind. Th
 | **`statement_loader`** | `load_statements` | HTTP | Retrieves and stores 8 quarters of income, balance sheet, and cash flow statements. |
 | **`populate_price_data`** | `populate_price_data` | HTTP | Loads historical price data for tracked tickers into BigQuery. |
 | **`technicals_collector`** | `refresh_technicals` | HTTP | Collects a suite of daily technical indicators (SMA, EMA, RSI, etc.). |
+| **`refresh_stock_metadata`** | `refresh_stock_metadata` | HTTP | Builds a BigQuery table of earnings call dates and publishes a completion event. |
 | **`transcript_collector`**| `refresh_transcripts`| Pub/Sub | Fetches the latest quarterly earnings call transcript and publishes a message with its location. |
-| **`transcript_summarizer`**| `create_summaries` | Pub/Sub | Generates an AI-powered summary for each new transcript message. |
+| **`transcript_summarizer`**| `create_transcript_summaries` | Pub/Sub | Generates an AI-powered summary for each new transcript message. |
 
 ## 7. Setup and Deployment
 
@@ -97,7 +107,7 @@ This project was built with professional-grade engineering practices in mind. Th
     # Navigate into a service directory, e.g., price_updater
     cd price_updater
     # Deploy the function (example)
-    gcloud functions deploy update-prices --gen2 --runtime python312 ...
+    gcloud functions deploy price_updater --gen2 --runtime python312 ...
     ```
 5.  **Deploy the Workflow**:
     ```bash
@@ -110,5 +120,6 @@ This project was built with professional-grade engineering practices in mind. Th
 * **Automated Execution**: The pipeline is configured via Cloud Scheduler to run automatically every weekday at 5:00 AM Eastern Time.
 * **Manual Execution**: The pipeline can be triggered at any time by running the following `gcloud` command:
     ```bash
-    gcloud workflows run profitscout-pipeline    ```
+    gcloud workflows run profitscout-pipeline
+    ```
 


### PR DESCRIPTION
## Summary
- redraw architecture diagram for seven workflow services and transcript Pub/Sub flow
- document refresh_stock_metadata function in service table
- keep Gemini 2.0 Flash and example deployment command
- fix manual workflow run code block

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68754e1e301c8331ae8f38cbcdb63168